### PR TITLE
fix node rotating in applyConfig()

### DIFF
--- a/script.js
+++ b/script.js
@@ -104,6 +104,6 @@ function isReserved(i) {
 
 function applyConfig({ node, degree, id, type }) {
   node.classList.add("line", type);
-  node.style.rotate = `${degree}deg`;
+  node.style.transform = `rotate(${degree}deg)`;
   node.id = id;
 }


### PR DESCRIPTION
`<HTMLElement>.style.rotate = "90deg"` does not rotate an element. You need to use the `transforn` property and the CSS `rotate` function. I.e:

`<HTMLElement>.style.transform = "rotate(90deg)"`

This PR implements the above behaviour